### PR TITLE
Removed duplicate declaration of the Forecast class Feature/#71

### DIFF
--- a/lib/forecast.js
+++ b/lib/forecast.js
@@ -1,10 +1,8 @@
-
-export class Forecast {
 /**
  * Represents a weather forecast.
  * @class
  */
-class Forecast {
+export class Forecast {
   /**
    * Creates an instance of Forecast.
    * @constructor
@@ -26,3 +24,4 @@ class Forecast {
     this.precipitationAmount = precipitationAmount;
   }
 }
+


### PR DESCRIPTION
This pull request addresses the issue of duplicate declaration of the Forecast class in forecast.js. The duplicate declaration has been removed, ensuring code clarity and eliminating redundancy. This change simplifies the codebase and improves maintainability.
closes #71 